### PR TITLE
Resolve conflicts with existing keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,24 @@
 
   function rename(obj, fn) {
     var newKey;
+    var deferred = {};
     for (var key in obj) {
       if (!obj.hasOwnProperty(key)) {
         continue;
       }
       newKey = fn(key);
       if (newKey !== undefined && newKey !== key) {
-        obj[newKey] = obj[key];
+        if (newKey in obj) {
+          deferred[newKey] = obj[key];
+        }
+        else {
+          obj[newKey] = obj[key];
+        }
         delete obj[key];
       }
+    }
+    for (var key in deferred) {
+       obj[key] = deferred[key];
     }
     return obj;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -27,4 +27,11 @@ describe('rename keys', function () {
       if (prop == 'b') return 'c'
     }), {a: 1, c: 1});
   });
+
+  it('should rename keys without conflicts', function () {
+    assert.deepEqual(rename({a: 1, b: 2, c: 3, d: 4}, function(prop) {
+      var renameMap = {a : 'd', b: 'c', c: 'b', d: 'a'};
+      return renameMap[prop];
+    }), {a: 4, b: 3, c: 2, d: 1});
+  });
 });


### PR DESCRIPTION
If the new key already exists, it is lost. 
eg {a: 1, b: 2, c: 3, d: 4}
renaming a => d, b => c, c => b & d => a, will result in { b: 2, a: 1}

With this change it should rename correctly as {a:4, b:3, c:2, d:1}
